### PR TITLE
resolve unique key warning for header component

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -45,6 +45,7 @@ function Header({ siteTitle }) {
               NavLinks.map((node) => (
                 <Link
                   to={node.href}
+                  key={node.href}
                   className="block md:inline-block mt-4 md:mt-0 mr-6 no-underline text-black"
                 >
                   {node.name}


### PR DESCRIPTION
There was a React warning `warning: Each child in a list should have a unique "key" prop` for the the header component since the NavLinks are being iterated through to generate `Link` components without a key. This PR resolves this warning by adding a unique key property to each Link.